### PR TITLE
feat: Year Timeline (Gantt sticky) — DESIGN-004 (#97)

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -8,7 +8,8 @@ import PostExtra from '@/components/post/PostExtra';
 import PostList from '@/components/post/PostList';
 import { generateMetadata as generateSEOMetadata } from '@/components/seo';
 import { routing } from '@/i18n/routing';
-import { type ResumeData } from '@/types';
+import { getCompanyAccent } from '@/lib/companyColors';
+import { type ExperienceTimelineData, type ResumeData } from '@/types';
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -41,6 +42,14 @@ export default async function LocalePage({ params }: { params: Promise<{ locale:
     year: /\d{4}/.exec(exp.start)?.[0] ?? '',
   }));
 
+  const timeline: ExperienceTimelineData[] = data.work.experiences.map((exp, index) => ({
+    id: `exp-${index}`,
+    company: exp.company,
+    start: exp.start,
+    end: exp.end,
+    accent: getCompanyAccent(exp.company),
+  }));
+
   const sections = [
     { label: t('education'), href: '#education' },
     { label: t('extras'), href: '#extras' },
@@ -48,7 +57,13 @@ export default async function LocalePage({ params }: { params: Promise<{ locale:
   ];
 
   return (
-    <Layout person={data.person} experiences={experiences} sections={sections}>
+    <Layout
+      person={data.person}
+      experiences={experiences}
+      sections={sections}
+      timeline={timeline}
+      lang={locale as 'fr' | 'en'}
+    >
       <Hero person={data.person} locale={locale} />
       <PostList title={t('work')} list={data.work.experiences} sectionId="work" idPrefix="exp" />
       <PostList title={t('education')} list={data.education.schools} sectionId="education" />

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import MainContent from '@/components/layout/MainContent';
 import Sidebar from '@/components/layout/Sidebar';
 import SidebarIdentity from '@/components/layout/SidebarIdentity';
+import YearTimeline from '@/components/timeline/YearTimeline';
 import { useScrollTracking } from '@/hooks/useScrollTracking';
 import { LayoutProps } from '@/types';
 
@@ -12,7 +13,14 @@ import { LayoutProps } from '@/types';
 // sticky timeline header.
 const SCROLL_OFFSET = 120;
 
-const Layout: React.FC<LayoutProps> = ({ person, experiences = [], sections = [], children }) => {
+const Layout: React.FC<LayoutProps> = ({
+  person,
+  experiences = [],
+  sections = [],
+  children,
+  timeline = [],
+  lang = 'fr',
+}) => {
   const mainRef = useRef<HTMLElement>(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
@@ -102,6 +110,9 @@ const Layout: React.FC<LayoutProps> = ({ person, experiences = [], sections = []
       </nav>
 
       <MainContent ref={mainRef} className="pt-16 md:pt-0">
+        {timeline.length > 0 ? (
+          <YearTimeline experiences={timeline} activeId={activeExpId} onExpClick={handleExpClick} lang={lang} />
+        ) : null}
         <div className="p-3 lg:p-6 xl:px-12">{children}</div>
         <footer className="border-border text-body-muted border-t px-12 py-6 font-serif print:hidden">
           © {new Date().getFullYear()}, Built with&nbsp;

--- a/components/timeline/YearTimeline.tsx
+++ b/components/timeline/YearTimeline.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import React, { useMemo } from 'react';
+
+import { isCurrentPosition, parseYearMonth } from '@/lib/dateUtils';
+import { assignRows, MAX_YEAR, MIN_YEAR, type TimelineItem, yearToPct } from '@/lib/timelineUtils';
+import { type ExperienceTimelineData } from '@/types';
+
+interface YearTimelineProps {
+  experiences: ExperienceTimelineData[];
+  activeId: string;
+  onExpClick: (id: string) => void;
+  lang: 'fr' | 'en';
+}
+
+const YearTimeline: React.FC<YearTimelineProps> = ({ experiences, activeId, onExpClick, lang }) => {
+  const { packed, byId } = useMemo(() => {
+    const rawItems: Omit<TimelineItem, 'row'>[] = experiences.map((exp) => {
+      const start = parseYearMonth(exp.start) ?? MIN_YEAR;
+      const end = isCurrentPosition(exp.end) ? MAX_YEAR : (parseYearMonth(exp.end) ?? MAX_YEAR);
+      return { id: exp.id, company: exp.company, start, end };
+    });
+
+    const packedItems = assignRows(rawItems);
+    const idMap = new Map<string, ExperienceTimelineData>(experiences.map((exp) => [exp.id, exp]));
+
+    return { packed: packedItems, byId: idMap };
+  }, [experiences]);
+
+  const numRows = Math.max(1, ...packed.map((p) => p.row + 1));
+
+  const evenYears: number[] = [];
+  for (let y = 2010; y <= 2024; y += 2) {
+    evenYears.push(y);
+  }
+
+  return (
+    <div
+      className="border-border bg-bg/88 sticky top-0 z-20 border-b pt-3 pr-7 pb-2 pl-7 backdrop-blur-md print:hidden"
+      aria-label={lang === 'fr' ? 'Frise chronologique' : 'Career timeline'}
+    >
+      <div className="relative mb-[0.35rem] h-4">
+        {evenYears.map((y) => (
+          <span
+            key={y}
+            className="text-body-muted absolute -translate-x-1/2 text-[0.625rem] whitespace-nowrap tabular-nums"
+            style={{ left: `${yearToPct(y)}%` }}
+          >
+            {y}
+          </span>
+        ))}
+      </div>
+      <div className="relative" style={{ height: `calc(${numRows} * 22px + 4px)` }}>
+        {packed.map((item) => {
+          const exp = byId.get(item.id);
+          if (!exp) return null;
+          const leftPct = yearToPct(item.start);
+          const widthPct = yearToPct(item.end) - yearToPct(item.start);
+          const isActive = item.id === activeId;
+          const dateLabel = isCurrentPosition(exp.end)
+            ? `${exp.start} – ${lang === 'fr' ? 'présent' : 'present'}`
+            : `${exp.start} – ${exp.end}`;
+          return (
+            <button
+              type="button"
+              key={item.id}
+              onClick={() => onExpClick(item.id)}
+              title={`${exp.company} · ${dateLabel}`}
+              aria-label={`${exp.company}, ${dateLabel}`}
+              className={[
+                'absolute flex h-4.5 cursor-pointer items-center overflow-hidden rounded-[3px] border-none px-1.75 text-[0.625rem] leading-none text-white',
+                'bg-(--chip-accent)',
+                'transition-[opacity,transform,box-shadow] duration-200 motion-reduce:transition-none',
+                'hover:-translate-y-px hover:opacity-100',
+                'focus-visible:opacity-100 focus-visible:shadow-[0_0_0_2px_var(--color-bg),0_0_0_4px_var(--chip-accent)] focus-visible:outline-none',
+                isActive ? 'opacity-100 shadow-[0_0_0_2px_var(--color-bg),0_0_0_4px_var(--chip-accent)]' : 'opacity-55',
+              ].join(' ')}
+              style={
+                {
+                  left: `${leftPct}%`,
+                  width: `max(${widthPct}%, 30px)`,
+                  top: `${item.row * 22}px`,
+                  '--chip-accent': exp.accent,
+                } as React.CSSProperties
+              }
+            >
+              <span className="truncate">{exp.company}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default YearTimeline;

--- a/lib/dateUtils.ts
+++ b/lib/dateUtils.ts
@@ -1,0 +1,46 @@
+// Maps month abbreviations (FR + EN) to a 0-based month index.
+const MONTH_MAP: Record<string, number> = {
+  jan: 0,
+  fev: 1,
+  fév: 1,
+  feb: 1,
+  mar: 2,
+  avr: 3,
+  apr: 3,
+  mai: 4,
+  may: 4,
+  juin: 5,
+  jun: 5,
+  juil: 6,
+  jul: 6,
+  août: 7,
+  aoû: 7,
+  aug: 7,
+  sept: 8,
+  sep: 8,
+  oct: 9,
+  nov: 10,
+  déc: 11,
+  dec: 11,
+};
+
+// Regex alternation: longer/more specific tokens first so a prefix token
+// (e.g. "sep") does not shadow a longer one ("sept"). Both map to the same
+// value anyway, but order keeps intent clear.
+const MONTH_RE = /(sept|sep|juin|juil|août|aoû|jan|fév|fev|feb|mar|avr|apr|mai|may|jun|jul|aug|oct|nov|déc|dec)/;
+
+export function parseYearMonth(str: string): number | null {
+  if (!str) return null;
+
+  const yearMatch = /\d{4}/.exec(str);
+  if (!yearMatch) return null;
+  const year = Number(yearMatch[0]);
+
+  const monthMatch = str.toLowerCase().match(MONTH_RE);
+
+  return year + (monthMatch ? (MONTH_MAP[monthMatch[1]] ?? 0) / 12 : 0);
+}
+
+export function isCurrentPosition(endStr: string): boolean {
+  return !endStr || /présent|present/i.test(endStr);
+}

--- a/lib/timelineUtils.ts
+++ b/lib/timelineUtils.ts
@@ -1,0 +1,30 @@
+export interface TimelineItem {
+  id: string;
+  company: string;
+  start: number;
+  end: number;
+  row: number;
+}
+
+// Greedy row-packing: place each mission on the first row whose previous
+// mission ended early enough (gap tolerance ≈ 2 weeks) to avoid visual overlap.
+export function assignRows(items: Omit<TimelineItem, 'row'>[]): TimelineItem[] {
+  const sorted = [...items].sort((a, b) => a.start - b.start);
+  const rowEnds: number[] = [];
+  return sorted.map((item) => {
+    let row = 0;
+    // eslint-disable-next-line security/detect-object-injection
+    while (rowEnds[row] !== undefined && rowEnds[row] > item.start + 0.04) {
+      row++;
+    }
+    // eslint-disable-next-line security/detect-object-injection
+    rowEnds[row] = item.end;
+    return { ...item, row };
+  });
+}
+
+export const MIN_YEAR = 2010;
+export const MAX_YEAR = 2025.83;
+const SPAN = MAX_YEAR - MIN_YEAR;
+
+export const yearToPct = (y: number): number => ((y - MIN_YEAR) / SPAN) * 100;

--- a/types/index.ts
+++ b/types/index.ts
@@ -150,11 +150,22 @@ export interface SectionNavItem {
   external?: boolean;
 }
 
+// Timeline (Gantt) metadata for an experience.
+export interface ExperienceTimelineData {
+  id: string;
+  company: string;
+  start: string; // ex: "Oct. 2023"
+  end: string; // ex: "Juil. 2023" ou "" pour le poste actuel
+  accent: string; // oklch(...) ou var(--color-accent)
+}
+
 export interface LayoutProps {
   person: Person;
   experiences?: ExperienceNavItem[];
   sections?: SectionNavItem[];
   children: React.ReactNode;
+  timeline?: ExperienceTimelineData[];
+  lang?: 'fr' | 'en';
 }
 
 export interface PageProps {


### PR DESCRIPTION
## Résumé

Implémente le composant **`YearTimeline`** (ticket #97 / DESIGN-004, epic #93) : un diagramme de Gantt horizontal du parcours professionnel, collé en haut (`position: sticky`) de la zone de scroll principale. Chaque expérience est un chip coloré dont la largeur est proportionnelle à la durée ; un algorithme de row-packing évite les chevauchements ; le chip actif (synchro scroll) est mis en avant.

## Critères d'acceptation couverts

- [x] Composant `position: sticky; top: 0` dans la zone de scroll principale
- [x] Axe temporel 2010 → 2025, années paires marquées
- [x] Chip coloré par entreprise (map `COMPANY_ACCENT`)
- [x] Largeur du chip proportionnelle à la durée de la mission
- [x] Row-packing greedy : missions qui se chevauchent placées sur des rangées différentes
- [x] Outline visible sur le chip de l'expérience active (synchro scroll via `useScrollTracking`)
- [x] Clic sur un chip → scroll vers la card de l'expérience (réutilise `handleExpClick`)
- [x] Hover/`title` → tooltip entreprise + dates
- [x] Adapté aux 3 thèmes (dark / clean / bold), tokens `--color-*`
- [x] Fond flou `backdrop-filter: blur(12px)` + `color-mix`

## Fichiers

| Fichier | Type |
|---|---|
| `lib/dateUtils.ts` | nouveau — `parseYearMonth`, `isCurrentPosition` |
| `lib/timelineUtils.ts` | nouveau — `assignRows`, `yearToPct`, bornes d'axe |
| `components/timeline/YearTimeline.tsx` | nouveau — composant client |
| `types/index.ts` | `ExperienceTimelineData` + props `timeline`/`lang` |
| `app/[locale]/page.tsx` | construction des données timeline |
| `components/layout.tsx` | intégration sticky dans `MainContent` |
| `app/globals.css` | styles Gantt (3 thèmes, print, reduced-motion) |

## Écarts par rapport à la spec du ticket (justifiés)

- **`MONTH_MAP` étendu FR + EN.** La spec ne fournissait que les mois FR, mais `app/data/en.json` utilise des mois anglais (`Jul.`, `June`, `May`, `Aug.`, `Feb.`…). Sans cet ajout, la timeline du locale EN aurait mal positionné les chips. Le comportement requis est préservé : `parseYearMonth('Oct. 2023') === 2023.75`, `parseYearMonth('présent') === null`.
- **Tokens CSS** : la spec utilisait `--c-bg`/`--c-border` ; le repo expose `--color-bg`/`--color-border` (Tailwind v4). Adaptés en conséquence.
- **Tests unitaires différés** au ticket dédié **DESIGN-010** (« Tests Unit + E2E Playwright ») : le repo n'a pas encore de runner de tests (`yarn test` = `lint` + `type-check`). Le code des utils est pur et testable tel quel. Décision validée avec le mainteneur.

## Validation

- `yarn type-check` ✅
- `yarn lint` ✅
- `yarn build` ✅ (5 pages statiques générées)
- Sanity check parsing FR + EN sur les 12 expériences réelles ✅

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added an interactive timeline visualization displaying work experiences across years (2010–2024)
* Experience entries are now clickable with visual accent colors per company
* Timeline dates automatically format with language-specific labels, including "present" for current positions
* Sticky year axis provides easy reference while browsing experience details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->