### PR TITLE
Mise à jour des expériences depuis le CV

### DIFF
--- a/app/data/en.json
+++ b/app/data/en.json
@@ -14,125 +14,123 @@
     "title": "Work Experiences",
     "experiences": [
       {
-        "title": "Freelance Frontend Developer",
+        "title": "Frontend Tech Lead",
         "city": "Saint-Jorioz",
         "country": "France",
         "company": "Greenweez",
+        "freelance": true,
         "start": "Oct. 2023",
         "end": "",
         "tags": [
-          { "name": "NextJS", "ref": "js" },
-          { "name": "React 18", "ref": "js" },
-          { "name": "React Query", "ref": "js" },
+          { "name": "React 19", "ref": "js" },
+          { "name": "Next.js 15", "ref": "js" },
+          { "name": "TypeScript", "ref": "js" },
           { "name": "Tailwind CSS", "ref": "css" },
-          { "name": "Jest", "ref": "test" },
-          { "name": "Playwright", "ref": "test" }
+          { "name": "React Query", "ref": "js" },
+          { "name": "Apollo GraphQL", "ref": "js" },
+          { "name": "Playwright", "ref": "test" },
+          { "name": "Jest", "ref": "test" }
         ],
         "description": [
           {
-            "text": "Technical lead and release management of www.greenweez.com. Performance and SEO improvements by reducing bundle size and auditing synchronous and asynchronous API calls",
+            "text": "Frontend Tech Lead & Release Manager for the e-commerce site www.greenweez.com",
             "list": [
-              "Migration to React 18 & Next 13",
-              "Set up E2E tests with Playwright",
-              "Frontend: React/Next.js, Tailwind CSS, React Query, Jest, React Testing Library",
-              "Middleware: Apollo GraphQL",
-              "Design System: Lerna, Vite, Storybook 7"
+              "Technical lead on frontend evolutions for greenweez.com",
+              "Technical referent of a 4-developer team: scoping, code review, best practices and mentoring of 2 junior developers",
+              "Set up unit, integration and E2E tests with Jest, React Testing Library and Playwright",
+              "Improved performance, SEO, UI/UX and accessibility (50% reduction of the JavaScript bundle)",
+              "Migration to the Next.js App Router, React 18→19, Next 13→15 and Node.js 18→22",
+              "Referent for the UI/UX consistency of frontend features"
             ]
           }
         ]
       },
       {
-        "title": "Freelance Frontend Developer",
+        "title": "Frontend Developer",
         "city": "Paris",
         "country": "France",
         "company": "Club Med",
+        "freelance": true,
         "start": "Nov. 2021",
         "end": "Jul. 2023",
         "tags": [
           { "name": "TypeScript", "ref": "js" },
-          { "name": "React 18", "ref": "js" },
-          { "name": "Redux", "ref": "js" },
+          { "name": "React", "ref": "js" },
           { "name": "Ts.ED", "ref": "js" },
+          { "name": "Node", "ref": "back" },
           { "name": "Tailwind CSS", "ref": "css" },
           { "name": "Jest", "ref": "test" },
           { "name": "Cypress", "ref": "test" }
         ],
         "description": [
           {
-            "text": "Development of a data visualization tool for internal users and partners",
+            "text": "Data-visualization site for Club Med's internal teams and partners, integrated within the API team",
             "list": [
-              "TypeScript, React 18, Redux, Ts.ED, Node",
-              "Unit and integration testing with Jest and Cypress",
-              "Git process, code reviews, continuous delivery & pair programming",
-              "Tailwind and CSS3 integration"
+              "Referent for the UI/UX consistency of frontend features",
+              "Frontend development with React and Tailwind",
+              "Set up unit and integration tests with Jest and Cypress",
+              "Improved UI/UX and accessibility",
+              "Integrated within the API team (5 developers), in direct contact with users to improve data display",
+              "Agile practices: code reviews, pair programming and continuous delivery within a team of 8 developers (front & back)"
             ]
           }
         ]
       },
       {
-        "title": "Freelance Frontend Developer",
+        "title": "Frontend Developer",
         "city": "Paris",
         "country": "France",
         "company": "Rakuten",
+        "freelance": true,
         "start": "Nov. 2020",
         "end": "Sept. 2021",
         "tags": [
-          { "name": "ReactJS", "ref": "js" },
-          { "name": "NextJS", "ref": "js" },
+          { "name": "React", "ref": "js" },
+          { "name": "Next.js", "ref": "js" },
+          { "name": "TypeScript", "ref": "js" },
           { "name": "Redux", "ref": "js" },
+          { "name": "Material UI", "ref": "css" },
+          { "name": "Sendbird", "ref": "js" },
           { "name": "React Testing Library", "ref": "test" },
           { "name": "Cypress", "ref": "test" }
         ],
         "description": [
           {
-            "text": "Built an instant messaging between a seller and a buyer for the second-hand marketplace. Redesigned the listing form for second-hand sales",
+            "text": "Built an instant messaging feature between a seller and a buyer for the second-hand marketplace. Redesigned the product listing form for second-hand sales",
             "list": [
-              "Frontend development with ReactJS, NextJS, Redux, Tachyons",
-              "Set up unit and integration tests with React Testing Library and Cypress",
-              "Used Sendbird API for messaging",
-              "Agile team with 2 frontend devs and 4 backend devs for the second-hand section",
-              "Close collaboration with the web designer for integration"
+              "Frontend development with React.js, Next.js, Redux and Tachyons",
+              "Set up test coverage (unit and integration) with React Testing Library and Cypress",
+              "Used the Sendbird API for messaging",
+              "Agile team with 2 frontend developers and 4 backend developers for the second-hand section",
+              "Ongoing collaboration with the web designer for integration"
             ]
           }
         ]
       },
       {
-        "title": "Freelance Full-stack Developer",
+        "title": "Full-stack Developer",
         "city": "Paris",
         "country": "France",
         "company": "ADSPL",
+        "freelance": true,
         "start": "June 2018",
-        "end": "June 2020",
+        "end": "Sept. 2020",
         "tags": [
-          {
-            "name": "ReactJS",
-            "ref": "js"
-          },
-          {
-            "name": "NextJS",
-            "ref": "js"
-          },
-          {
-            "name": "NodeJS",
-            "ref": "back"
-          },
-          {
-            "name": "Firebase",
-            "ref": "db"
-          },
-          {
-            "name": "Cypress",
-            "ref": "test"
-          }
+          { "name": "React", "ref": "js" },
+          { "name": "GraphQL", "ref": "js" },
+          { "name": "NodeJS", "ref": "back" },
+          { "name": "Firebase", "ref": "db" },
+          { "name": "Jest", "ref": "test" },
+          { "name": "Cypress", "ref": "test" }
         ],
         "description": [
           {
-            "text": "For the client UNAPL, development of a platform to collect their members' subscription",
+            "text": "Platform to collect the membership fees of a union's members (member area with payment)",
             "list": [
-              "Create from scratch a website with memberspace and two payment methods (Credit Card, SEPA)",
-              "Backend with NodeJS and link to Firebase",
-              "Setting up end-to-end tests with Cypress",
-              "Evaluate the needs and writing specifications"
+              "Frontend development with a member area and two payment methods (credit card & SEPA)",
+              "Backend development with NodeJS connected to Firebase",
+              "Set up automated tests, from unit (Jest) to E2E (Cypress)",
+              "Requirements gathering and writing of functional specifications"
             ]
           },
           {
@@ -141,296 +139,212 @@
         ]
       },
       {
-        "title": "Freelance Frontend Developer",
+        "title": "Frontend Developer",
         "city": "Paris",
         "country": "France",
         "company": "Club Med",
+        "freelance": true,
         "start": "June 2017",
         "end": "Jan. 2020",
         "tags": [
-          {
-            "name": "ReactJS",
-            "ref": "js"
-          },
-          {
-            "name": "GraphQL",
-            "ref": "js"
-          },
-          {
-            "name": "HTML5",
-            "ref": "html"
-          },
-          {
-            "name": "CSS3",
-            "ref": "css"
-          },
-          {
-            "name": "PostCSS",
-            "ref": "css"
-          },
-          {
-            "name": "ES6",
-            "ref": "js"
-          },
-          {
-            "name": "Flow",
-            "ref": "js"
-          },
-          {
-            "name": "NextJS",
-            "ref": "js"
-          },
-          {
-            "name": "Accessibility",
-            "ref": "a11y"
-          }
+          { "name": "React 16", "ref": "js" },
+          { "name": "GraphQL", "ref": "js" },
+          { "name": "Next.js", "ref": "js" },
+          { "name": "Flow", "ref": "js" },
+          { "name": "PostCSS", "ref": "css" },
+          { "name": "ES6", "ref": "js" },
+          { "name": "CSS3", "ref": "css" },
+          { "name": "Accessibility", "ref": "a11y" }
         ],
         "description": [
           {
-            "text": "New features and graphic redesign of customer account",
+            "text": "New features and graphic redesign of the customer account on the commercial site (www.clubmed.fr)",
             "list": [
-              "Frontend team with Agile method on the new responsive site",
-              "Unit and Integration testing with Jest, Chai, Enzyme, Sinon",
-              "Flow typing, Git process, code reviews, continuous delivery & pair programming",
-              "Integration PostCSS, TailWind, CSS3"
+              "JavaScript development with React, Next.js, GraphQL, Redux and Flow",
+              "Integration with PostCSS, Tailwind and CSS3",
+              "Unit and integration tests with Jest, Chai, Enzyme and Sinon",
+              "Implementation of accessibility standards on the site",
+              "3 agile teams (Kanban) made up of 3 developers, 1 Product Owner and 1 QA",
+              "Team referent for inter-team communication"
             ]
           }
         ]
       },
       {
-        "title": "Freelance Frontend Developer",
+        "title": "Frontend Developer",
         "city": "Paris",
         "country": "France",
         "company": "Verifone",
+        "freelance": true,
         "start": "Mar. 2017",
         "end": "May 2017",
         "tags": [
-          {
-            "name": "AngularJS",
-            "ref": "js"
-          },
-          {
-            "name": "HTML5",
-            "ref": "html"
-          },
-          {
-            "name": "CSS3",
-            "ref": "css"
-          },
-          {
-            "name": "Bootstrap",
-            "ref": "css"
-          }
+          { "name": "AngularJS", "ref": "js" },
+          { "name": "HTML5", "ref": "html" },
+          { "name": "CSS3", "ref": "css" },
+          { "name": "Bootstrap", "ref": "css" },
+          { "name": "Java Spring", "ref": "back" }
         ],
         "description": [
           {
-            "text": "Feature on the internal website"
+            "text": "Intranet redesign",
+            "list": [
+              "Frontend redesign with AngularJS and Bootstrap",
+              "Set up Git Flow",
+              "Backend architecture in micro-services (Netflix) and Java Spring"
+            ]
           }
         ]
       },
       {
-        "title": "Freelance Web Developer",
+        "title": "Web Integrator",
         "city": "Paris",
         "country": "France",
         "company": "L'Equipe",
+        "freelance": true,
         "start": "Oct. 2016",
         "end": "Feb. 2017",
         "tags": [
-          {
-            "name": "SASS",
-            "ref": "css"
-          },
-          {
-            "name": "HTML5",
-            "ref": "html"
-          },
-          {
-            "name": "CSS3",
-            "ref": "css"
-          }
+          { "name": "SASS", "ref": "css" },
+          { "name": "HTML5", "ref": "html" },
+          { "name": "CSS3", "ref": "css" },
+          { "name": "jQuery", "ref": "js" },
+          { "name": "Grunt", "ref": "js" }
         ],
         "description": [
           {
             "text": "Integration of the new graphic charter",
-            "list": [
-              "HTML & CSS Integration (Mobile and desktop)",
-              "Works closely with the marketing team and the designers"
-            ]
+            "list": ["HTML and CSS integration (desktop and mobile)", "Direct link with designers and marketing"]
           }
         ]
       },
       {
-        "title": "Mobile developer",
+        "title": "Web & Mobile Developer",
         "city": "Paris",
         "country": "France",
         "company": "Geoks",
-        "start": "Dec. 2016",
+        "freelance": true,
+        "start": "Jan. 2017",
         "end": "Jan. 2017",
         "tags": [
-          {
-            "name": "Cordova",
-            "ref": "js"
-          },
-          {
-            "name": "Backbone.js",
-            "ref": "js"
-          },
-          {
-            "name": "Less",
-            "ref": "css"
-          },
-          {
-            "name": "Handlebars.js",
-            "ref": "js"
-          }
+          { "name": "Cordova", "ref": "js" },
+          { "name": "Backbone.js", "ref": "js" },
+          { "name": "Less", "ref": "css" },
+          { "name": "Handlebars.js", "ref": "js" },
+          { "name": "Underscore.js", "ref": "js" }
         ],
         "description": [
           {
-            "text": "Tracking activity application for an e-bike with Bluetooth LE and GPS"
+            "text": "Activity tracking application for an e-bike via Bluetooth LE and GPS",
+            "list": ["Hybrid application (Cordova.js) for iOS and Android"]
           }
         ]
       },
       {
-        "title": "Web & Mobile Lead Programmer",
+        "title": "Web & Mobile Tech Lead",
         "city": "Paris",
         "country": "France",
         "company": "CGI",
         "start": "May 2014",
         "end": "Sept. 2016",
         "tags": [
-          {
-            "name": "Web-application",
-            "ref": "html"
-          },
-          {
-            "name": "HTML5",
-            "ref": "html"
-          },
-          {
-            "name": "CSS3",
-            "ref": "css"
-          },
-          {
-            "name": "Backbone.js",
-            "ref": "js"
-          },
-          {
-            "name": "Dust.js / Handlebar.js",
-            "ref": "js"
-          },
-          {
-            "name": "Phone Gap",
-            "ref": "js"
-          }
+          { "name": "Backbone.js", "ref": "js" },
+          { "name": "RequireJS", "ref": "js" },
+          { "name": "Dust.js", "ref": "js" },
+          { "name": "Cordova", "ref": "js" },
+          { "name": "Handlebars", "ref": "js" },
+          { "name": "HTML5", "ref": "html" },
+          { "name": "CSS3", "ref": "css" }
         ],
         "description": [
           {
-            "text": "Sephora website for smartphones",
+            "text": "Sephora: technical scoping of evolutions. Monitoring and delivery of changes with a team of two developers",
             "list": [
-              "Technical project framing for the evolutions. Monitoring and implementation of changes with a team of two developers",
-              "Makes a multi-language website (IT, PL, CZ, ES)",
-              "Application developments for iOS with Cordova/Phone Gap (iPad Color Profile et iPhone MySephora)",
-              "Webmobile part of iPhone & Android application: design integration and maintenance"
+              "Evolutions of the Sephora web-mobile site and creation of multi-language versions (IT, PL, CZ, ES)",
+              "Evolutions of internal iOS applications with Cordova/Phone Gap (iPad Color Profile and iPhone MySephora)",
+              "Integration and maintenance of the web-mobile part of the iPhone and Android applications"
             ]
           },
           {
-            "text": "Responsibilities: Lead programmer with a team of two developers"
+            "text": "Responsibilities: technical referent of a team of two developers"
           }
         ]
       },
       {
-        "title": "Software engineer",
+        "title": "Information Technology Engineer",
+        "city": "Paris",
+        "country": "France",
+        "company": "CGI",
+        "start": "Nov. 2013",
+        "end": "May 2014",
+        "tags": [
+          { "name": "HTML5", "ref": "html" },
+          { "name": "CSS3", "ref": "css" },
+          { "name": "LESS", "ref": "css" },
+          { "name": "jQuery", "ref": "js" },
+          { "name": "Responsive", "ref": "css" }
+        ],
+        "description": [
+          {
+            "text": "Louis Vuitton: redesign of the Flash site into a responsive HTML5 and CSS3 site",
+            "list": [
+              "Built the website's web client interface from the ATG base",
+              "Compatibility for all screen sizes. Adapted for IE8/7/6 compatibility"
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Information Technology Engineer",
         "city": "Paris",
         "country": "France",
         "company": "CGI",
         "start": "Sept. 2012",
-        "end": "May 2014",
+        "end": "Oct. 2013",
         "tags": [
-          {
-            "name": "Web application",
-            "ref": "html"
-          },
-          {
-            "name": "Backbone.js",
-            "ref": "js"
-          },
-          {
-            "name": "Responsive",
-            "ref": "css"
-          },
-          {
-            "name": "LESS",
-            "ref": "css"
-          },
-          {
-            "name": "Dust.js",
-            "ref": "js"
-          },
-          {
-            "name": "iOS Application",
-            "ref": "ios"
-          }
+          { "name": "Backbone.js", "ref": "js" },
+          { "name": "RequireJS", "ref": "js" },
+          { "name": "Dust.js", "ref": "js" },
+          { "name": "Cordova", "ref": "js" },
+          { "name": "HTML5", "ref": "html" },
+          { "name": "CSS3", "ref": "css" }
         ],
         "description": [
           {
-            "text": "Sephora project:",
+            "text": "Sephora: development of the web-mobile site (smartphone target only)",
             "list": [
-              "Realisation of Sephora webmobile site",
+              "Development of the Sephora web-mobile site",
               "Update of Sephora's iPhone application",
-              "Update and maintain of Sephora's iPad application Color Profile"
-            ]
-          },
-          {
-            "text": "Louis Vuitton project:",
-            "list": [
-              "Development of the user interface for Louis Vuitton website from ATG base",
-              "Responsive design and compatibility with IE8/7/6."
+              "Maintenance and evolution of the iPad Color Profile application"
             ]
           }
         ]
       },
       {
-        "title": "Web mobile analyst",
+        "title": "Web & Mobile Developer Analyst",
         "context": "Final year project",
         "city": "Lyon",
         "country": "France",
         "company": "Logica",
         "start": "Feb. 2012",
-        "end": "Aug. 2012",
+        "end": "Sept. 2012",
         "tags": [
-          {
-            "name": "Web-application",
-            "ref": "html"
-          },
-          {
-            "name": "jQuery Mobile",
-            "ref": "js"
-          },
-          {
-            "name": "Twitter Bootstrap",
-            "ref": "css"
-          },
-          {
-            "name": "Phone Gap",
-            "ref": "js"
-          },
-          {
-            "name": "Cocoa Touch",
-            "ref": "ios"
-          }
+          { "name": "jQuery Mobile", "ref": "js" },
+          { "name": "Twitter Bootstrap", "ref": "css" },
+          { "name": "Objective-C", "ref": "ios" }
         ],
         "description": [
           {
-            "text": "CMS integration in the mobility",
+            "text": "Integrate the notion of CMS with mobility",
             "list": [
-              "Software package of events management, responsible of CMS problematic, CMS studies and tests. Followed by pre-sales of the project feasibility study, ripening workshop, costing of the project cost.",
-              "iOS developments"
+              "Event management software package, in charge of the CMS problem: CMS study and testing. Pre-sales follow-up, feasibility study, maturation workshop and project cost estimation.",
+              "Participation in iOS application development"
             ]
           }
         ]
       },
       {
-        "title": "Intern in IT",
+        "title": "Web Developer Analyst",
         "context": "One-year internship",
         "city": "Pembroke Pines",
         "country": "USA",
@@ -438,42 +352,24 @@
         "start": "July 2010",
         "end": "July 2011",
         "tags": [
-          {
-            "name": "HTML",
-            "ref": "html"
-          },
-          {
-            "name": "PHP",
-            "ref": "back"
-          },
-          {
-            "name": "jQuery",
-            "ref": "js"
-          },
-          {
-            "name": "MySQL",
-            "ref": "db"
-          },
-          {
-            "name": "Cocoa Touch",
-            "ref": "ios"
-          },
-          {
-            "name": "Joomla",
-            "ref": "cms"
-          }
+          { "name": "HTML", "ref": "html" },
+          { "name": "CSS", "ref": "css" },
+          { "name": "PHP", "ref": "back" },
+          { "name": "jQuery", "ref": "js" },
+          { "name": "Objective-C", "ref": "ios" },
+          { "name": "Joomla", "ref": "cms" }
         ],
         "description": [
           {
-            "text": "Learn and use different languages and frameworks",
+            "text": "Discover the different languages and develop several applications in complete autonomy",
             "list": [
-              "Web Application in a CRM (HTML, PHP, JavaScript-jQuery, and MySQL)",
-              "iPad Application for the booth in Air Shows (Objective-C, Cocoa Touch)",
-              "CMS Setting"
+              "Web application in a CRM to manage the TBM aircraft maintenance center in Florida",
+              "iPad application for air shows",
+              "Configuration of a Joomla CMS"
             ]
           },
           {
-            "text": "I was in a complete autonomy to discover the different languages and to develop the different applications. I provided support to the users after acceptance-test and insured the transfer of the application to the head quarter in France."
+            "text": "I was in complete autonomy to discover the different languages and develop the various applications. I provided support to users after acceptance and ensured the transfer of the applications to the headquarters in France. My goal was to leave clear documentation for the next developers."
           }
         ]
       }

--- a/app/data/fr.json
+++ b/app/data/fr.json
@@ -203,7 +203,7 @@
         "company": "L'Equipe",
         "freelance": true,
         "start": "Oct. 2016",
-        "end": "Fev. 2017",
+        "end": "Fév. 2017",
         "tags": [
           { "name": "SASS", "ref": "css" },
           { "name": "HTML5", "ref": "html" },

--- a/app/data/fr.json
+++ b/app/data/fr.json
@@ -14,295 +14,202 @@
     "title": "Expériences professionnelles",
     "experiences": [
       {
-        "title": "Freelance Développeur Frontend",
+        "title": "Référent technique Front-end",
         "city": "Saint-Jorioz",
         "country": "France",
         "company": "Greenweez",
+        "freelance": true,
         "start": "Oct. 2023",
         "end": "",
         "tags": [
-          {
-            "name": "NextJS",
-            "ref": "js"
-          },
-          {
-            "name": "React 18",
-            "ref": "js"
-          },
-          {
-            "name": "React Query",
-            "ref": "js"
-          },
-          {
-            "name": "Tailwind CSS",
-            "ref": "css"
-          },
-          {
-            "name": "Jest",
-            "ref": "test"
-          },
-          {
-            "name": "Playwright",
-            "ref": "test"
-          }
+          { "name": "React 19", "ref": "js" },
+          { "name": "Next.js 15", "ref": "js" },
+          { "name": "TypeScript", "ref": "js" },
+          { "name": "Tailwind CSS", "ref": "css" },
+          { "name": "React Query", "ref": "js" },
+          { "name": "Apollo GraphQL", "ref": "js" },
+          { "name": "Playwright", "ref": "test" },
+          { "name": "Jest", "ref": "test" }
         ],
         "description": [
           {
-            "text": "Rôle de référent technique et gestion de release de www.greenweez.com. Optimisation des performances et du SEO avec réduction de taille de bundle et analyse d'appels API synchrones et asynchrones",
+            "text": "Tech Lead Frontend & Release Manager sur le site e-commerce www.greenweez.com",
             "list": [
-              "Migration vers React 18 & Next 13",
-              "Mise en place de tests E2E avec Playwright",
-              "Front: React/NextJs, Tailwind CSS, React Query, Jest, React Testing Library",
-              "Middleware: Apollo GraphQL",
-              "Design System: Lerna, Vite, Storybook 7"
+              "Pilotage technique des évolutions frontend sur greenweez.com",
+              "Référent technique d'une équipe de 4 développeurs : cadrage, revue de code, bonnes pratiques et accompagnement de 2 développeurs juniors",
+              "Mise en place de tests unitaires, d'intégration et E2E avec Jest, React Testing Library et Playwright",
+              "Amélioration des performances, du SEO, de l'UI/UX et de l'accessibilité (réduction de 50% du bundle JavaScript)",
+              "Migration vers l'App Router Next.js, React 18→19, Next 13→15 et Node.js 18→22",
+              "Référent de la cohérence UI/UX des fonctionnalités front"
             ]
           }
         ]
       },
       {
-        "title": "Freelance Développeur Frontend",
+        "title": "Développeur Front-end",
         "city": "Paris",
         "country": "France",
         "company": "Club Med",
+        "freelance": true,
         "start": "Nov. 2021",
         "end": "Juil. 2023",
         "tags": [
-          {
-            "name": "TypeScript",
-            "ref": "js"
-          },
-          {
-            "name": "React 18",
-            "ref": "js"
-          },
-          {
-            "name": "Redux",
-            "ref": "js"
-          },
-          {
-            "name": "Ts.ED",
-            "ref": "js"
-          },
-          {
-            "name": "Tailwind CSS",
-            "ref": "css"
-          },
-          {
-            "name": "Jest",
-            "ref": "test"
-          },
-          {
-            "name": "Cypress",
-            "ref": "test"
-          }
+          { "name": "TypeScript", "ref": "js" },
+          { "name": "React", "ref": "js" },
+          { "name": "Ts.ED", "ref": "js" },
+          { "name": "Node", "ref": "back" },
+          { "name": "Tailwind CSS", "ref": "css" },
+          { "name": "Jest", "ref": "test" },
+          { "name": "Cypress", "ref": "test" }
         ],
         "description": [
           {
-            "text": "Développement d'un outil de data visualisation pour l'interne et les partenaires",
+            "text": "Site de data-visualisation pour les internes et les partenaires du Club Med, intégré à l'équipe API",
             "list": [
-              "TypeScript, React 18, Redux, Ts.ED, Node",
-              "Tests unitaires et d’intégration avec Jest, Cypress",
-              "Git process, code reviews, continuous delivery & pair programming",
-              "Intégration de Tailwind et CSS3"
+              "Référent de la cohérence UI/UX des fonctionnalités front",
+              "Développement front avec React et Tailwind",
+              "Mise en place de tests unitaires et d'intégration avec Jest et Cypress",
+              "Amélioration de l'UI/UX et de l'accessibilité",
+              "Intégré à l'équipe API (5 développeurs), en relation directe avec les utilisateurs pour l'amélioration de l'affichage des données",
+              "Pratiques agiles : code reviews, pair programming et livraison continue au sein d'une équipe de 8 développeurs (front & back)"
             ]
           }
         ]
       },
       {
-        "title": "Freelance Développeur Frontend",
+        "title": "Développeur Front-end",
         "city": "Paris",
         "country": "France",
         "company": "Rakuten",
+        "freelance": true,
         "start": "Nov. 2020",
         "end": "Sept. 2021",
         "tags": [
-          {
-            "name": "ReactJS",
-            "ref": "js"
-          },
-          {
-            "name": "NextJS",
-            "ref": "js"
-          },
-          {
-            "name": "Redux",
-            "ref": "js"
-          },
-          {
-            "name": "React Testing Library",
-            "ref": "test"
-          },
-          {
-            "name": "Cypress",
-            "ref": "test"
-          }
+          { "name": "React", "ref": "js" },
+          { "name": "Next.js", "ref": "js" },
+          { "name": "TypeScript", "ref": "js" },
+          { "name": "Redux", "ref": "js" },
+          { "name": "Material UI", "ref": "css" },
+          { "name": "Sendbird", "ref": "js" },
+          { "name": "React Testing Library", "ref": "test" },
+          { "name": "Cypress", "ref": "test" }
         ],
         "description": [
           {
-            "text": "Intégration d'une messagerie instantanée entre un vendeur et un acheteur pour la partie vente d'occasion. Refonte du formulaire de mise en vente d’un produit pour la vente d’occasion",
+            "text": "Intégration d'une messagerie instantanée entre un vendeur et un acheteur pour la partie vente d'occasion. Refonte du formulaire de mise en vente d'un produit pour la vente d'occasion",
             "list": [
-              "Développement front avec ReactJS, NextJS, Redux, Tachyons",
-              "Mise en place d’une couverture de tests (unitaire et intégration) avec React Testing Library et Cypress",
-              "Utilisation de l’API Sendbird pour la messagerie",
-              "Une équipe en mode agile avec 2 dev front et 4 dev back pour la section de vente d’occasion",
-              "En dialogue permanent avec le web designer pour l’intégration"
+              "Développement front avec React.js, Next.js, Redux et Tachyons",
+              "Mise en place d'une couverture de tests (unitaire et intégration) avec React Testing Library et Cypress",
+              "Utilisation de l'API Sendbird pour la messagerie",
+              "Équipe en mode agile avec 2 développeurs front et 4 développeurs back pour la section vente d'occasion",
+              "En dialogue permanent avec le web designer pour l'intégration"
             ]
           }
         ]
       },
       {
-        "title": "Freelance Développeur Full-stack",
+        "title": "Développeur Full-stack",
         "city": "Paris",
         "country": "France",
         "company": "ADSPL",
+        "freelance": true,
         "start": "Juin 2018",
         "end": "Sept. 2020",
         "tags": [
-          {
-            "name": "ReactJS",
-            "ref": "js"
-          },
-          {
-            "name": "NextJS",
-            "ref": "js"
-          },
-          {
-            "name": "NodeJS",
-            "ref": "back"
-          },
-          {
-            "name": "Firebase",
-            "ref": "db"
-          },
-          {
-            "name": "Cypress",
-            "ref": "test"
-          }
+          { "name": "React", "ref": "js" },
+          { "name": "GraphQL", "ref": "js" },
+          { "name": "NodeJS", "ref": "back" },
+          { "name": "Firebase", "ref": "db" },
+          { "name": "Jest", "ref": "test" },
+          { "name": "Cypress", "ref": "test" }
         ],
         "description": [
           {
-            "text": "Développement d'un site pour le réglèment de la cotisation du syndicat UNAPL (Espace client avec paiement).",
+            "text": "Site permettant de récupérer les cotisations des membres d'un syndicat (espace client avec paiement)",
             "list": [
-              "Développement site front avec un espace client et deux modes de paiement (CB & SEPA)",
-              "Développement Backend avec NodeJS et connecté à Firebase",
-              "Mise en place des tests automatisés, de unitaire (Jest) à E2E (Cypress)",
+              "Développement du site front avec un espace client et deux modes de paiement (CB & SEPA)",
+              "Développement backend avec NodeJS connecté à Firebase",
+              "Mise en place des tests automatisés, de l'unitaire (Jest) à l'E2E (Cypress)",
               "Recueil du besoin et écriture des SFD"
             ]
           },
           {
-            "text": "Mission réalisée en temps partiel"
+            "text": "Mission réalisée à temps partiel"
           }
         ]
       },
       {
-        "title": "Freelance Développeur Frontend",
+        "title": "Développeur Front-end",
         "city": "Paris",
         "country": "France",
         "company": "Club Med",
+        "freelance": true,
         "start": "Juin 2017",
         "end": "Jan. 2020",
         "tags": [
-          {
-            "name": "React 16",
-            "ref": "js"
-          },
-          {
-            "name": "GraphQL",
-            "ref": "js"
-          },
-          {
-            "name": "HTML5",
-            "ref": "html"
-          },
-          {
-            "name": "CSS3",
-            "ref": "css"
-          },
-          {
-            "name": "PostCSS",
-            "ref": "css"
-          },
-          {
-            "name": "ES6",
-            "ref": "js"
-          },
-          {
-            "name": "Flow",
-            "ref": "js"
-          },
-          {
-            "name": "NextJS",
-            "ref": "js"
-          },
-          {
-            "name": "Accessibilité",
-            "ref": "a11y"
-          }
+          { "name": "React 16", "ref": "js" },
+          { "name": "GraphQL", "ref": "js" },
+          { "name": "Next.js", "ref": "js" },
+          { "name": "Flow", "ref": "js" },
+          { "name": "PostCSS", "ref": "css" },
+          { "name": "ES6", "ref": "js" },
+          { "name": "CSS3", "ref": "css" },
+          { "name": "Accessibilité", "ref": "a11y" }
         ],
         "description": [
           {
-            "text": "Evolutions et refonte graphique sur l'espace client du site commercial",
+            "text": "Évolutions et refonte graphique sur l'espace client du site commercial (www.clubmed.fr)",
             "list": [
-              "Equipes Front en Agile sur le nouveau site Responsive",
-              "Tests unitaire et d'intégration avec Jest, Chai, Enzyme, Sinon",
-              "Flow typing, Git process, code reviews, continuous delivery & pair programming",
-              "Integration PostCSS, Tailwind, CSS3"
+              "Développement JavaScript avec React, Next.js, GraphQL, Redux et Flow",
+              "Intégration avec PostCSS, Tailwind et CSS3",
+              "Tests unitaires et d'intégration avec Jest, Chai, Enzyme et Sinon",
+              "Mise en place des normes d'accessibilité sur le site",
+              "3 équipes en mode agile (Kanban) composées de 3 développeurs, 1 Product Owner et 1 QA",
+              "Référent de son équipe pour la communication inter-équipes"
             ]
           }
         ]
       },
       {
-        "title": "Freelance Développeur Frontend",
+        "title": "Développeur Front-end",
         "city": "Paris",
         "country": "France",
         "company": "Verifone",
+        "freelance": true,
         "start": "Mars 2017",
         "end": "Mai 2017",
         "tags": [
-          {
-            "name": "AngularJS",
-            "ref": "js"
-          },
-          {
-            "name": "HTML5",
-            "ref": "html"
-          },
-          {
-            "name": "CSS3",
-            "ref": "css"
-          },
-          {
-            "name": "Bootstrap",
-            "ref": "css"
-          }
+          { "name": "AngularJS", "ref": "js" },
+          { "name": "HTML5", "ref": "html" },
+          { "name": "CSS3", "ref": "css" },
+          { "name": "Bootstrap", "ref": "css" },
+          { "name": "Java Spring", "ref": "back" }
         ],
         "description": [
           {
-            "text": "Réalisation de fonctionnalité sur leur outil interne",
-            "list": ["Refonte front avec Angularjs et Bootstrap", "Mise en place de Git Flow"]
+            "text": "Refonte de l'intranet",
+            "list": [
+              "Refonte front avec AngularJS et Bootstrap",
+              "Mise en place de Git Flow",
+              "Architecture back en micro-services (Netflix) et Java Spring"
+            ]
           }
         ]
       },
       {
-        "title": "Freelance Intégrateur Web",
+        "title": "Intégrateur Web",
         "city": "Paris",
         "country": "France",
         "company": "L'Equipe",
+        "freelance": true,
         "start": "Oct. 2016",
         "end": "Fev. 2017",
         "tags": [
-          {
-            "name": "SASS",
-            "ref": "css"
-          },
-          {
-            "name": "HTML5",
-            "ref": "html"
-          },
-          {
-            "name": "CSS3",
-            "ref": "css"
-          }
+          { "name": "SASS", "ref": "css" },
+          { "name": "HTML5", "ref": "html" },
+          { "name": "CSS3", "ref": "css" },
+          { "name": "jQuery", "ref": "js" },
+          { "name": "Grunt", "ref": "js" }
         ],
         "description": [
           {
@@ -312,33 +219,24 @@
         ]
       },
       {
-        "title": "Développeur mobile",
+        "title": "Développeur web-mobile",
         "city": "Paris",
         "country": "France",
         "company": "Geoks",
-        "start": "Dec. 2016",
+        "freelance": true,
+        "start": "Jan. 2017",
         "end": "Jan. 2017",
         "tags": [
-          {
-            "name": "Cordova",
-            "ref": "js"
-          },
-          {
-            "name": "Backbone.js",
-            "ref": "js"
-          },
-          {
-            "name": "Less",
-            "ref": "css"
-          },
-          {
-            "name": "Handlebars.js",
-            "ref": "js"
-          }
+          { "name": "Cordova", "ref": "js" },
+          { "name": "Backbone.js", "ref": "js" },
+          { "name": "Less", "ref": "css" },
+          { "name": "Handlebars.js", "ref": "js" },
+          { "name": "Underscore.js", "ref": "js" }
         ],
         "description": [
           {
-            "text": "Application de tracking d’activité de vélo électrique via Bluetooth LE et GPS"
+            "text": "Application de tracking d'activité de vélo électrique via Bluetooth LE et GPS",
+            "list": ["Application hybride (Cordova.js) pour iOS et Android"]
           }
         ]
       },
@@ -350,139 +248,103 @@
         "start": "Mai 2014",
         "end": "Sept. 2016",
         "tags": [
-          {
-            "name": "Web-application",
-            "ref": "html"
-          },
-          {
-            "name": "HTML5",
-            "ref": "html"
-          },
-          {
-            "name": "CSS3",
-            "ref": "css"
-          },
-          {
-            "name": "Backbone.js",
-            "ref": "js"
-          },
-          {
-            "name": "Dust.js / Handlebar.js",
-            "ref": "js"
-          },
-          {
-            "name": "Phone Gap",
-            "ref": "js"
-          }
+          { "name": "Backbone.js", "ref": "js" },
+          { "name": "RequireJS", "ref": "js" },
+          { "name": "Dust.js", "ref": "js" },
+          { "name": "Cordova", "ref": "js" },
+          { "name": "Handlebars", "ref": "js" },
+          { "name": "HTML5", "ref": "html" },
+          { "name": "CSS3", "ref": "css" }
         ],
         "description": [
           {
-            "text": "Sephora, site webmobile et applications",
+            "text": "Sephora : cadrage technique des évolutions. Suivi et réalisation des évolutions avec une équipe de deux développeurs",
             "list": [
-              "Cadrage technique des évolutions. Suivi et réalisation des évolutions avec une équipe de deux développeurs",
-              "Création de version multi-langues pour le site webmobile (IT, PL, CZ, ES)",
-              "Evolutions des applications iOS internes, avec Cordova/Phone Gap (iPad Color Profile et iPhone MySephora)",
-              "Intégration et maintenance de la partie webmobile des applications iPhone et Android"
+              "Évolutions du site web-mobile de Sephora et création de versions multi-langues (IT, PL, CZ, ES)",
+              "Évolutions des applications iOS internes avec Cordova/Phone Gap (iPad Color Profile et iPhone MySephora)",
+              "Intégration et maintenance de la partie web-mobile des applications iPhone et Android"
             ]
           },
           {
-            "text": "Responsabilités : Référent technique d'une équipe de deux développeurs"
+            "text": "Responsabilités : référent technique d'une équipe de deux développeurs"
           }
         ]
       },
       {
-        "title": "Ingénieur en Technologie de l'Information",
+        "title": "Ingénieur en technologie de l'information",
+        "city": "Paris",
+        "country": "France",
+        "company": "CGI",
+        "start": "Nov. 2013",
+        "end": "Mai 2014",
+        "tags": [
+          { "name": "HTML5", "ref": "html" },
+          { "name": "CSS3", "ref": "css" },
+          { "name": "LESS", "ref": "css" },
+          { "name": "jQuery", "ref": "js" },
+          { "name": "Responsive", "ref": "css" }
+        ],
+        "description": [
+          {
+            "text": "Louis Vuitton : refonte du site Flash en un site responsive HTML5 et CSS3",
+            "list": [
+              "Réalisation de l'interface client web du site à partir du socle ATG",
+              "Compatibilité pour toutes les tailles d'écran. Adaptation pour la compatibilité IE8/7/6"
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Ingénieur en technologie de l'information",
         "city": "Paris",
         "country": "France",
         "company": "CGI",
         "start": "Sept. 2012",
-        "end": "Mai 2014",
+        "end": "Oct. 2013",
         "tags": [
-          {
-            "name": "Web-application",
-            "ref": "html"
-          },
-          {
-            "name": "Backbone.js",
-            "ref": "js"
-          },
-          {
-            "name": "Responsive",
-            "ref": "css"
-          },
-          {
-            "name": "LESS",
-            "ref": "css"
-          },
-          {
-            "name": "Dust.js",
-            "ref": "js"
-          },
-          {
-            "name": "Application iOS",
-            "ref": "ios"
-          }
+          { "name": "Backbone.js", "ref": "js" },
+          { "name": "RequireJS", "ref": "js" },
+          { "name": "Dust.js", "ref": "js" },
+          { "name": "Cordova", "ref": "js" },
+          { "name": "HTML5", "ref": "html" },
+          { "name": "CSS3", "ref": "css" }
         ],
         "description": [
           {
-            "text": "Projet Sephora :",
+            "text": "Sephora : réalisation du site web-mobile (cible smartphone uniquement)",
             "list": [
-              "Réalisation du site web-mobile de Sephora",
-              "Mise à jour de l’application iPhone de Sephora",
-              "Reprise et évolution de l’application iPad Color Profile"
-            ]
-          },
-          {
-            "text": "Projet Louis Vuitton :",
-            "list": [
-              "Réalisation de l’interface client Web du site à partir du socle ATG",
-              "Compatibilité pour toutes les tailles d’écran. Adaptation pour compatibilité IE8/7/6"
+              "Réalisation du site web-mobile de Sephora",
+              "Mise à jour de l'application iPhone de Sephora",
+              "Reprise et évolution de l'application iPad Color Profile"
             ]
           }
         ]
       },
       {
-        "title": "Analyste développeur mobile et web",
+        "title": "Analyste développeur web et mobile",
         "context": "Stage projet de fin d'étude",
         "city": "Lyon",
         "country": "France",
         "company": "Logica",
         "start": "Fév. 2012",
-        "end": "Août 2012",
+        "end": "Sept. 2012",
         "tags": [
-          {
-            "name": "Web-application",
-            "ref": "html"
-          },
-          {
-            "name": "jQuery Mobile",
-            "ref": "js"
-          },
-          {
-            "name": "Twitter Bootstrap",
-            "ref": "css"
-          },
-          {
-            "name": "Phone Gap",
-            "ref": "js"
-          },
-          {
-            "name": "Cocoa Touch",
-            "ref": "ios"
-          }
+          { "name": "jQuery Mobile", "ref": "js" },
+          { "name": "Twitter Bootstrap", "ref": "css" },
+          { "name": "Objective-C", "ref": "ios" }
         ],
         "description": [
           {
-            "text": "Intégrer la notion de CMS avec la mobilite",
+            "text": "Intégrer la notion de CMS avec la mobilité",
             "list": [
-              "Progiciel de gestion d’événements, en charge de la problématique de CMS, étude et test de CMS. Suivi de l'avant-vente du projet, étude de faisabilité, atelier de maturation, chiffrage du coût du projet.",
-              "Participation aux développements d’applications iOS"
+              "Progiciel de gestion d'événements, en charge de la problématique de CMS : étude et test de CMS. Suivi de l'avant-vente du projet, étude de faisabilité, atelier de maturation et chiffrage du coût du projet.",
+              "Participation aux développements d'applications iOS"
             ]
           }
         ]
       },
       {
-        "title": "Analyste développeur",
+        "title": "Analyste développeur web",
         "context": "Stage année de césure",
         "city": "Pembroke Pines",
         "country": "USA",
@@ -490,42 +352,24 @@
         "start": "Juil. 2010",
         "end": "Juil. 2011",
         "tags": [
-          {
-            "name": "HTML",
-            "ref": "html"
-          },
-          {
-            "name": "PHP",
-            "ref": "back"
-          },
-          {
-            "name": "jQuery",
-            "ref": "js"
-          },
-          {
-            "name": "MySQL",
-            "ref": "db"
-          },
-          {
-            "name": "Objective-C",
-            "ref": "ios"
-          },
-          {
-            "name": "Joomla",
-            "ref": ""
-          }
+          { "name": "HTML", "ref": "html" },
+          { "name": "CSS", "ref": "css" },
+          { "name": "PHP", "ref": "back" },
+          { "name": "jQuery", "ref": "js" },
+          { "name": "Objective-C", "ref": "ios" },
+          { "name": "Joomla", "ref": "cms" }
         ],
         "description": [
           {
-            "text": "Découvrir et utiliser les différents langages",
+            "text": "Découvrir les différents langages et développer plusieurs applications en complète autonomie",
             "list": [
-              "Applications web dans un CRM",
-              "Application iPad pour les salons aéronautiques",
-              "Configuration d’un CMS"
+              "Application web dans un CRM pour la gestion du centre de maintenance des avions TBM en Floride",
+              "Application iPad pour les salons aéronautiques",
+              "Configuration d'un CMS Joomla"
             ]
           },
           {
-            "text": "J’étais en complète autonomie pour découvrir les différents langages et pour développer les différentes applications. J’ai fourni le support aux utilisateurs après validation et assurer le transfert des applications au siège social en France. Mon but était de laisser une documentation claire pour les prochains développeurs."
+            "text": "J'étais en complète autonomie pour découvrir les différents langages et développer les différentes applications. J'ai fourni le support aux utilisateurs après validation et assuré le transfert des applications au siège social en France. Mon but était de laisser une documentation claire pour les prochains développeurs."
           }
         ]
       }
@@ -536,12 +380,12 @@
     "title": "Education",
     "schools": [
       {
-        "title": "Ecole supérieure de Chimie, Physique et Electronique de Lyon (ESCPE)",
+        "title": "Ecole supérieure de Chimie, Physique et Electronique de Lyon (ESCPE)",
         "city": "Lyon",
         "country": "France",
         "company": "Ecole d'ingénieur",
-        "context": "Electronique, Télécoms et informatique",
-        "specialty": "Majeur Systèmes Informatiques Distribués",
+        "context": "Electronique, Télécoms et informatique",
+        "specialty": "Majeur Systèmes Informatiques Distribués",
         "start": "2007",
         "end": "2012",
         "description": [

--- a/app/data/heroSkills.ts
+++ b/app/data/heroSkills.ts
@@ -36,12 +36,12 @@ export const HERO_SKILLS: Record<HeroLocale, HeroSkill[]> = {
 export const HERO_STATS: Record<HeroLocale, HeroStat[]> = {
   fr: [
     { label: "ans d'exp.", value: 15 },
-    { label: 'missions', value: 12 },
+    { label: 'missions', value: 13 },
     { label: 'technos', value: 28, suffix: '+' },
   ],
   en: [
     { label: 'years exp.', value: 15 },
-    { label: 'missions', value: 12 },
+    { label: 'missions', value: 13 },
     { label: 'techs', value: 28, suffix: '+' },
   ],
 };

--- a/components/post/PostHeader.tsx
+++ b/components/post/PostHeader.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
 import React from 'react';
 
 import { Tag } from '@/components/tag';
@@ -13,30 +16,38 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   start,
   end,
   tags,
-}) => (
-  <header>
-    <div className="flex flex-wrap items-center gap-2 print:inline">
-      <h3 className="text-heading text-xl font-bold print:mr-2 print:inline-block print:text-base">{title}</h3>
-      {freelance ? (
-        <span className="border-brand/40 text-brand rounded-full border px-2 py-0.5 text-xs font-medium print:mr-2 print:inline-block">
-          Freelance
-        </span>
-      ) : null}
-    </div>
-    <p className="text-body-muted overflow-hidden text-sm print:mr-2 print:inline-block">
-      {company}, {city}, {country} {context ? ` - ${context}` : ''}
-    </p>
-    <p className="text-body-muted mb-2 overflow-hidden text-xs print:mr-2 print:-mb-2 print:inline-block">
-      {start} - {end}
-    </p>
-    <div className="mb-2 flex flex-wrap items-center gap-2 print:-mt-1 print:mr-2 print:mb-1 print:inline-block">
-      {tags
-        ? tags.map((tag, index) => (
-            <Tag tag={tag.ref} name={tag.name} key={`Tag-${start}-${end}-${tag.ref}-${index}`} />
-          ))
-        : null}
-    </div>
-  </header>
-);
+}) => {
+  const t = useTranslations('post');
+
+  return (
+    <header>
+      <div className="flex flex-wrap items-center gap-2 print:inline">
+        <h3 className="text-heading text-xl font-bold print:mr-2 print:inline-block print:text-base">{title}</h3>
+        {freelance ? (
+          <span
+            role="status"
+            aria-label={t('badge.freelance')}
+            className="border-brand/40 text-brand rounded-full border px-2 py-0.5 text-xs font-medium print:mr-2 print:inline-block"
+          >
+            {t('badge.freelance')}
+          </span>
+        ) : null}
+      </div>
+      <p className="text-body-muted overflow-hidden text-sm print:mr-2 print:inline-block">
+        {company}, {city}, {country} {context ? ` - ${context}` : ''}
+      </p>
+      <p className="text-body-muted mb-2 overflow-hidden text-xs print:mr-2 print:-mb-2 print:inline-block">
+        {start} - {end}
+      </p>
+      <div className="mb-2 flex flex-wrap items-center gap-2 print:-mt-1 print:mr-2 print:mb-1 print:inline-block">
+        {tags
+          ? tags.map((tag, index) => (
+              <Tag tag={tag.ref} name={tag.name} key={`Tag-${start}-${end}-${tag.ref}-${index}`} />
+            ))
+          : null}
+      </div>
+    </header>
+  );
+};
 
 export default PostHeader;

--- a/components/post/PostHeader.tsx
+++ b/components/post/PostHeader.tsx
@@ -3,9 +3,26 @@ import React from 'react';
 import { Tag } from '@/components/tag';
 import { PostHeaderProps } from '@/types';
 
-const PostHeader: React.FC<PostHeaderProps> = ({ title, company, city, country, context, start, end, tags }) => (
+const PostHeader: React.FC<PostHeaderProps> = ({
+  title,
+  company,
+  city,
+  country,
+  context,
+  freelance,
+  start,
+  end,
+  tags,
+}) => (
   <header>
-    <h3 className="text-heading text-xl font-bold print:mr-2 print:inline-block print:text-base">{title}</h3>
+    <div className="flex flex-wrap items-center gap-2 print:inline">
+      <h3 className="text-heading text-xl font-bold print:mr-2 print:inline-block print:text-base">{title}</h3>
+      {freelance ? (
+        <span className="border-brand/40 text-brand rounded-full border px-2 py-0.5 text-xs font-medium print:mr-2 print:inline-block">
+          Freelance
+        </span>
+      ) : null}
+    </div>
     <p className="text-body-muted overflow-hidden text-sm print:mr-2 print:inline-block">
       {company}, {city}, {country} {context ? ` - ${context}` : ''}
     </p>

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,5 +15,10 @@
   "hero": {
     "availability": "Available · Freelance",
     "skillsTitle": "Key skills"
+  },
+  "post": {
+    "badge": {
+      "freelance": "Freelance"
+    }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -15,5 +15,10 @@
   "hero": {
     "availability": "Disponible · Freelance",
     "skillsTitle": "Compétences clés"
+  },
+  "post": {
+    "badge": {
+      "freelance": "Freelance"
+    }
   }
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -29,6 +29,7 @@ export interface Experience {
   country: string;
   company: string;
   context?: string;
+  freelance?: boolean;
   start: string;
   end: string;
   tags?: Tag[];
@@ -96,6 +97,7 @@ export interface PostHeaderProps {
   city?: string;
   country?: string;
   context?: string;
+  freelance?: boolean;
   start?: string;
   end?: string;
   tags?: Tag[];


### PR DESCRIPTION
## Contexte

Report du CV à jour dans les données du site : réécriture des expériences professionnelles dans `app/data/fr.json`, traduction dans `app/data/en.json`, et réalignement des tags sur la section « Technologies » de chaque expérience.

## Changements

- **13 expériences** (au lieu de 12) : l'entrée CGI « Ingénieur » fusionnée est scindée en deux pour coller au CV — Louis Vuitton (nov. 2013 – mai 2014) puis Sephora web-mobile (sept. 2012 – oct. 2013).
- **Descriptions** réécrites depuis le CV (PROJET → `text`, RÉALISATION → `list`), en FR et traduites en EN.
- **Intitulés** réécrits comme dans le CV, sans préfixe « Freelance » (ex. Greenweez → « Référent technique Front-end » / « Frontend Tech Lead »).
- **Tags ciblés** (~5–8 par expérience) alignés sur la section Technologies, outils annexes écartés (Figma, JIRA, Git…). Notamment : Redux retiré de Club Med 2021 et NextJS d'ADSPL (absents du CV) ; ajouts Apollo GraphQL, Java Spring, Material UI, Sendbird, Underscore.js.
- **Badge « Freelance »** affiché à côté du titre via un nouveau champ `freelance?: boolean` sur `Experience`, rendu dans `PostHeader`. Posé sur les 8 missions freelance (Greenweez, Club Med ×2, Rakuten, ADSPL, Verifone, L'Equipe, Geoks).
- **Corrections de dates** : bug `en.json` ADSPL (`June 2020` → `Sept. 2020`), Geoks (janv. 2017) et Logica (sept. 2012) alignés sur le CV.

## Fichiers

- `app/data/fr.json`, `app/data/en.json` — contenu des expériences + tags
- `types/index.ts` — champ `freelance` sur `Experience` et `PostHeaderProps`
- `components/post/PostHeader.tsx` — rendu du badge « Freelance »

## Vérification

- `yarn type-check` ✅ · `yarn lint` ✅ · prettier clean ✅
- Rendu `yarn dev` sur `/fr` et `/en` : 13 expériences, 8 badges Freelance, intitulés et tags conformes, date ADSPL corrigée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible "Freelance" indicator badge for applicable work entries.

* **Documentation**
  * Large refresh of the Work section (EN & FR): updated job titles, dates, technology tags, and expanded responsibility descriptions across many roles.
  * Minor education text normalization for display consistency.

* **UI**
  * Updated profile stats: "missions" count increased from 12 to 13.

* **Localization**
  * Added French and English strings for the new "Freelance" badge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->