### PR TITLE
feat: add cn() utility and migrate hero classes to Tailwind

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,12 @@
   /* Themed font families — overridden per [data-theme]. */
   --font-sans: var(--font-space-grotesk), system-ui, sans-serif;
   --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
+
+  /* Hero animations — exposed as `animate-*` utilities. */
+  --animate-char-reveal: char-reveal 0.6s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+  --animate-skill-reveal: skill-reveal 0.6s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+  --animate-blink-cursor: blink-cursor 1s steps(2, start) infinite;
+  --animate-pulse-dot: pulse-dot 2s infinite;
 }
 
 [data-theme='dark'] {
@@ -105,32 +111,12 @@ body,
     radial-gradient(circle at bottom left, rgba(142, 142, 214, 0.12), transparent 38%);
 }
 
-.hero-char {
-  display: inline-block;
-  opacity: 0;
-  transform: translateY(0.55em);
-  animation: char-reveal 0.6s cubic-bezier(0.2, 0.7, 0.3, 1) both;
-}
-
-.hero-cursor {
-  animation: blink-cursor 1s steps(2, start) infinite;
-}
-
-.hero-status-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 999px;
-  background: oklch(0.66 0.18 145);
-  animation: pulse-dot 2s infinite;
-}
-
-.hero-skill-item {
-  opacity: 0;
-  transform: translateY(18px);
-  animation: skill-reveal 0.6s cubic-bezier(0.2, 0.7, 0.3, 1) both;
-}
-
 @keyframes char-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(0.55em);
+  }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -138,6 +124,11 @@ body,
 }
 
 @keyframes skill-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -167,19 +158,5 @@ body,
 
   100% {
     box-shadow: 0 0 0 0 oklch(0.66 0.18 145 / 0);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .hero-char,
-  .hero-skill-item {
-    animation: none;
-    opacity: 1;
-    transform: none;
-  }
-
-  .hero-cursor,
-  .hero-status-dot {
-    animation: none;
   }
 }

--- a/components/hero/Hero.tsx
+++ b/components/hero/Hero.tsx
@@ -25,7 +25,10 @@ const Hero: React.FC<HeroProps> = ({ person, locale = 'fr' }) => {
         <div className="space-y-4 lg:space-y-8">
           <div className="flex flex-wrap items-center gap-3">
             <span className="bg-bg/70 text-heading border-border inline-flex items-center gap-2 rounded-full border px-4 py-2 text-[0.7rem] font-medium tracking-[0.24em] uppercase backdrop-blur-sm">
-              <span aria-hidden="true" className="hero-status-dot" />
+              <span
+                aria-hidden="true"
+                className="animate-pulse-dot h-[7px] w-[7px] rounded-full bg-[oklch(0.66_0.18_145)] motion-reduce:animate-none"
+              />
               {t('availability')}
             </span>
             <a
@@ -49,7 +52,7 @@ const Hero: React.FC<HeroProps> = ({ person, locale = 'fr' }) => {
                         return (
                           <span
                             key={`${character}-${delayIndex}`}
-                            className="hero-char"
+                            className="animate-char-reveal inline-block motion-reduce:animate-none"
                             style={{ animationDelay: `${120 + delayIndex * 45}ms` }}
                           >
                             {character}
@@ -64,7 +67,10 @@ const Hero: React.FC<HeroProps> = ({ person, locale = 'fr' }) => {
             </h1>
             <h2 className="text-body mt-5 text-lg sm:text-xl lg:text-2xl">
               {person.title}
-              <span aria-hidden="true" className="hero-cursor text-brand ml-2 inline-block font-mono">
+              <span
+                aria-hidden="true"
+                className="text-brand animate-blink-cursor ml-2 inline-block font-mono motion-reduce:animate-none"
+              >
                 ▌
               </span>
             </h2>

--- a/components/hero/SkillsGrid.tsx
+++ b/components/hero/SkillsGrid.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 
 import { getHeroSkillColor, getHeroSkills, getHeroSkillTint, type HeroLocale } from '@/app/data/heroSkills';
+import { cn } from '@/lib/cn';
 
 // Skill card: dynamic border/background from CSS custom properties, per-theme shadow.
-// hero-skill-item carries the keyframe entrance animation defined in globals.css — keep it.
-const SKILL_CARD = [
-  'hero-skill-item rounded-2xl p-4',
+// animate-skill-reveal plays the keyframe entrance animation (registered in globals.css).
+const SKILL_CARD = cn(
+  'animate-skill-reveal rounded-2xl p-4 motion-reduce:animate-none',
   'border border-[var(--skill-color)] bg-[var(--skill-tint)]',
   'theme-dark:shadow-[0_0_0_1px_color-mix(in_srgb,var(--skill-color)_25%,transparent),0_24px_48px_-32px_var(--skill-color)]',
-  'theme-bold:shadow-[4px_4px_0_0_color-mix(in_srgb,var(--skill-color)_55%,transparent)]',
-].join(' ');
+  'theme-bold:shadow-[4px_4px_0_0_color-mix(in_srgb,var(--skill-color)_55%,transparent)]'
+);
 
 interface SkillsGridProps {
   locale: HeroLocale;
@@ -22,7 +23,7 @@ const SkillsGrid: React.FC<SkillsGridProps> = ({ locale, sectionTitle }) => {
   return (
     <div>
       <p className="text-body-muted mb-4 text-xs font-medium tracking-[0.3em] uppercase">{sectionTitle}</p>
-      <div className="hero-skills-grid grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 gap-3">
         {skills.map((skill, index) => (
           <article
             key={`${skill.label}-${skill.sub}`}

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -7,6 +7,7 @@ import MainContent from '@/components/layout/MainContent';
 import Sidebar from '@/components/layout/Sidebar';
 import SidebarIdentity from '@/components/layout/SidebarIdentity';
 import { useScrollTracking } from '@/hooks/useScrollTracking';
+import { cn } from '@/lib/cn';
 import { LayoutProps } from '@/types';
 
 // Offset (px) applied when scrolling to a card so it is not hidden behind the
@@ -85,12 +86,12 @@ const Layout: React.FC<LayoutProps> = ({ person, experiences = [], sections = []
 
       <nav
         aria-label="Primary"
-        className={[
+        className={cn(
           'cv-sidebar bg-sidebar border-border z-40 w-61 shrink-0 overflow-y-auto border-r',
           'fixed top-16 bottom-0 left-0 transition-transform duration-300 ease-in-out md:static md:inset-y-0 md:h-screen md:translate-x-0',
           isDrawerOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0',
-          'print:hidden',
-        ].join(' ')}
+          'print:hidden'
+        )}
       >
         <Sidebar
           person={person}

--- a/components/layout/MainContent.tsx
+++ b/components/layout/MainContent.tsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import { cn } from '@/lib/cn';
+
 interface MainContentProps {
   children: React.ReactNode;
   className?: string;
@@ -12,9 +14,7 @@ interface MainContentProps {
 const MainContent = React.forwardRef<HTMLElement, MainContentProps>(({ children, className }, ref) => (
   <main
     ref={ref}
-    className={['cv-main flex-1 overflow-y-auto print:h-auto print:overflow-visible', 'h-screen', className ?? '']
-      .filter(Boolean)
-      .join(' ')}
+    className={cn('cv-main flex-1 overflow-y-auto print:h-auto print:overflow-visible', 'h-screen', className)}
   >
     {children}
   </main>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import LinkedinLogo from '@/components/assets/icons/linkedin-logo';
 import SidebarIdentity from '@/components/layout/SidebarIdentity';
 import LangToggle from '@/components/ui/LangToggle';
 import ThemeToggle from '@/components/ui/ThemeToggle';
+import { cn } from '@/lib/cn';
 import { getCompanyAccent } from '@/lib/companyColors';
 import { type ExperienceNavItem, type Person, type SectionNavItem } from '@/types';
 
@@ -50,11 +51,11 @@ const Sidebar: React.FC<SidebarProps> = ({
                     type="button"
                     aria-current={isActive ? 'true' : undefined}
                     onClick={() => onExpClick(exp.id)}
-                    className={[
+                    className={cn(
                       'flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-left text-sm',
                       'focus-visible:ring-accent focus:outline-none focus-visible:ring-2',
-                      isActive ? 'text-heading bg-card-hover font-semibold' : 'text-body-muted hover:text-body',
-                    ].join(' ')}
+                      isActive ? 'text-heading bg-card-hover font-semibold' : 'text-body-muted hover:text-body'
+                    )}
                   >
                     <span
                       aria-hidden="true"

--- a/components/layout/SidebarIdentity.tsx
+++ b/components/layout/SidebarIdentity.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 
+import { cn } from '@/lib/cn';
 import { type Person } from '@/types';
 
 interface SidebarIdentityProps {
@@ -16,7 +17,7 @@ const SidebarIdentity: React.FC<SidebarIdentityProps> = ({ person, className }) 
 
   return (
     <>
-      <header className={['flex items-center gap-3', className ?? ''].filter(Boolean).join(' ')}>
+      <header className={cn('flex items-center gap-3', className)}>
         <span
           aria-hidden="true"
           className="border-body-muted text-body-muted shadow-body-muted/50 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border text-sm font-bold shadow"

--- a/components/ui/LangToggle.tsx
+++ b/components/ui/LangToggle.tsx
@@ -5,6 +5,7 @@ import React, { useTransition } from 'react';
 
 import { usePathname, useRouter } from '@/i18n/navigation';
 import { type Locale, routing } from '@/i18n/routing';
+import { cn } from '@/lib/cn';
 
 const LangToggle: React.FC<{ className?: string }> = ({ className }) => {
   const locale = useLocale();
@@ -23,9 +24,7 @@ const LangToggle: React.FC<{ className?: string }> = ({ className }) => {
     <div
       role="radiogroup"
       aria-label="Language"
-      className={['border-border inline-flex items-center gap-1 rounded-full border p-1', className ?? '']
-        .filter(Boolean)
-        .join(' ')}
+      className={cn('border-border inline-flex items-center gap-1 rounded-full border p-1', className)}
     >
       {routing.locales.map((value) => {
         const isActive = locale === value;
@@ -39,11 +38,11 @@ const LangToggle: React.FC<{ className?: string }> = ({ className }) => {
             aria-label={label}
             disabled={isPending}
             onClick={() => switchLocale(value)}
-            className={[
+            className={cn(
               'inline-flex h-8 min-w-8 cursor-pointer items-center justify-center rounded-full px-3 text-xs font-semibold',
               'focus-visible:ring-accent focus:outline-none focus-visible:ring-2',
-              isActive ? 'bg-accent text-white' : 'text-body-muted hover:bg-card-hover hover:text-body',
-            ].join(' ')}
+              isActive ? 'bg-accent text-white' : 'text-body-muted hover:bg-card-hover hover:text-body'
+            )}
           >
             {label}
           </button>

--- a/components/ui/ThemeToggle.tsx
+++ b/components/ui/ThemeToggle.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import { type Theme, useTheme } from '@/hooks/useTheme';
+import { cn } from '@/lib/cn';
 
 type ThemeOption = {
   value: Theme;
@@ -79,9 +80,7 @@ const ThemeToggle: React.FC<{ className?: string }> = ({ className }) => {
     <div
       role="radiogroup"
       aria-label="Theme"
-      className={['border-border inline-flex items-center gap-1 rounded-full border p-1 backdrop-blur', className ?? '']
-        .filter(Boolean)
-        .join(' ')}
+      className={cn('border-border inline-flex items-center gap-1 rounded-full border p-1 backdrop-blur', className)}
     >
       {OPTIONS.map((opt) => {
         const isActive = theme === opt.value;
@@ -94,11 +93,11 @@ const ThemeToggle: React.FC<{ className?: string }> = ({ className }) => {
             aria-label={opt.label}
             title={opt.label}
             onClick={() => setTheme(opt.value)}
-            className={[
+            className={cn(
               'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full',
               'focus-visible:ring-accent focus:outline-none focus-visible:ring-2',
-              isActive ? 'bg-accent text-white' : 'text-body-muted hover:bg-card-hover hover:text-body',
-            ].join(' ')}
+              isActive ? 'bg-accent text-white' : 'text-body-muted hover:bg-card-hover hover:text-body'
+            )}
           >
             {opt.icon}
           </button>

--- a/lib/cn.ts
+++ b/lib/cn.ts
@@ -1,0 +1,8 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+// Merge class names with clsx (conditional logic, falsy filtering) and
+// tailwind-merge (resolves conflicting Tailwind utilities, last one wins).
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/lib/cn.ts
+++ b/lib/cn.ts
@@ -3,6 +3,6 @@ import { twMerge } from 'tailwind-merge';
 
 // Merge class names with clsx (conditional logic, falsy filtering) and
 // tailwind-merge (resolves conflicting Tailwind utilities, last one wins).
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "next": "^16.2.6",
     "next-intl": "4.8.3",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4209,6 +4209,7 @@ __metadata:
     prettier-plugin-tailwindcss: "npm:^0.6.14"
     react: "npm:^19.2.0"
     react-dom: "npm:^19.2.0"
+    tailwind-merge: "npm:^3.6.0"
     tailwindcss: "npm:^4.1.14"
     typescript: "npm:^5.9.3"
   languageName: unknown
@@ -5638,6 +5639,13 @@ __metadata:
   dependencies:
     "@pkgr/core": "npm:^0.2.9"
   checksum: 10c0/cc4d446806688ae0d728ae7bb3f53176d065cf9536647fb85bdd721dcefbd7bf94874df6799ff61580f2b03a392659219b778a9254ad499f9a1f56c34787c235
+  languageName: node
+  linkType: hard
+
+"tailwind-merge@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "tailwind-merge@npm:3.6.0"
+  checksum: 10c0/a728d929f4786bcb48641db4228cc8c006a7545491783a658fb4d24d177dab960620991d17805a047309228de50ab949ca8d9e112c30183da0432367796ae186
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Quoi

Deux changements liés au styling, sans impact visuel (rendu identique vérifié) :

### 1. Utilitaire `cn()` (clsx + tailwind-merge)
- Nouveau [`lib/cn.ts`](lib/cn.ts) : `cn(...) = twMerge(clsx(...))`.
- Remplace les `[...].filter(Boolean).join(' ')` verbeux par `cn(...)` dans `layout.tsx`, `MainContent.tsx`, `Sidebar.tsx`, `SidebarIdentity.tsx`, `LangToggle.tsx`, `ThemeToggle.tsx`. clsx ignore déjà les valeurs falsy → fini le `className ?? ''` / `.filter(Boolean)`, et tailwind-merge résout désormais les conflits d'utilitaires.
- Ajout de la dépendance `tailwind-merge`.

### 2. Migration des classes `.hero-*` de `globals.css` vers Tailwind
- Les 4 keyframes sont exposées comme tokens `--animate-*` dans `@theme` et utilisées via les utilitaires `animate-*` (`animate-char-reveal`, `animate-blink-cursor`, `animate-pulse-dot`, `animate-skill-reveal`).
- Keyframes rendues **autonomes** (`from`/`to`) pour éviter le piège v4 où `translate-y-*` écrit la propriété CSS `translate` (≠ `transform`).
- Accessibilité préservée via `motion-reduce:animate-none` (le bloc `@media (prefers-reduced-motion)` dédié aux animations hero devient inutile).
- `globals.css` ne conserve plus que le système de thèmes (`@theme`, `[data-theme]`, `@custom-variant`), les transitions, le pseudo-élément `.hero-surface::before` et les keyframes.

Ce travail **complète** le refactor déjà présent sur `master` (qui avait migré `.hero-name` et les ombres de cartes vers des variantes `theme-*:`). Après rebase, `Hero.tsx` combine `theme-dark:font-light theme-bold:font-extrabold` (master) et les tokens `animate-*` (cette PR).

## Pourquoi
Réduire le boilerplate de construction de classes et centraliser leur fusion, tout en sortant les dernières classes utilitaires de `globals.css` au profit de Tailwind.

## Vérification
- ✅ `yarn lint`, `yarn type-check`, `yarn build` verts.
- ✅ Rendu navigateur vérifié sur les 3 thèmes : animations OK, hero-name **dark 300 / clean 700 / bold 800**, ombres cartes **dark+bold présentes / clean absente**, aucune classe `.hero-*` résiduelle dans le DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Character-by-character reveal for the hero title
  * Blinking cursor effect in the hero section
  * Entrance reveal animations for skill cards
  * Pulsing status indicator in the hero area

* **Refactor**
  * Consistent class-name composition across UI components

* **Accessibility**
  * Updated reduced-motion handling for certain hero animations (behavior changed)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->