### PR TITLE
fix: remove www→apex redirect from Next.js to prevent ERR_TOO_MANY_REDIRECTS

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,25 +1,10 @@
-import createNextIntlPlugin from 'next-intl/plugin';
 import type { NextConfig } from 'next';
+import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  async redirects() {
-    return [
-      {
-        source: '/:path*',
-        has: [
-          {
-            type: 'host',
-            value: 'www.mcomper.at',
-          },
-        ],
-        destination: 'https://mcomper.at/:path*',
-        permanent: true,
-      },
-    ];
-  },
   // swcMinify is enabled by default in Next.js 15
   turbopack: {
     resolveAlias: {


### PR DESCRIPTION
## Problem

`ERR_TOO_MANY_REDIRECTS` in production on `www.mcomper.at`, introduced by PR #121.

The commit `fe16376` added a Next.js `redirects()` rule in `next.config.ts` to canonicalize `www.mcomper.at → mcomper.at`. This conflicts with the hosting-level redirect (Vercel domain settings), creating an infinite loop:

```
www.mcomper.at  →  (Next.js)  →  mcomper.at
mcomper.at      →  (Vercel)   →  www.mcomper.at
www.mcomper.at  →  (Next.js)  →  ...
```

## Fix

Remove the `redirects()` block from `next.config.ts`. The www-to-apex canonicalization is already handled by Vercel's primary domain setting — only one layer should own this redirect.

## Action required after merge

Verify in Vercel dashboard → Project → Domains that `mcomper.at` is set as the primary domain with redirect from `www.mcomper.at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js configuration and build settings, removing the previous domain redirect behavior and adjusting build-time configuration for improved import resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->